### PR TITLE
Update dependencies to resolve Flask/Werkzeug compatibility issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-Flask==2.1.0
-flask-cors==3.0.10
-numpy==1.22.0
-opencv-python-headless==4.5.5.64
-Pillow==9.0.0
-piexif==1.1.3
-psutil==5.9.0
-#RPi.GPIO==0.7.0
+Flask>=2.3.0,<3.0.0
+flask-cors>=3.0.10
+numpy>=1.22.0
+opencv-python-headless>=4.5.5
+Pillow>=9.0.0
+piexif>=1.1.3
+psutil>=5.9.0
+# RPi.GPIO with conditional installation for Raspberry Pi
 RPi.GPIO; platform_machine == 'aarch64'
-schedule==1.1.0
-python-crontab==2.6.0
-requests==2.28.1
+schedule>=1.1.0
+python-crontab>=2.6.0
+requests>=2.28.1


### PR DESCRIPTION
This PR updates the dependencies in requirements.txt to address the Flask/Werkzeug compatibility issue that was causing the installation verification to fail.

## Problem
The web service was failing to start due to an incompatibility between Flask 2.1.0 and Werkzeug 3.x:
```
ImportError: cannot import name 'url_quote' from 'werkzeug.urls'
```

## Solution
Instead of using exact versions like `Flask==2.1.0`, this PR implements a constraint-based approach:

1. Updates Flask to a minimum version of 2.3.0 (which is compatible with Werkzeug 3.x)
2. Sets minimum versions for other dependencies rather than pinning exact versions
3. Adds an upper bound to Flask (`<3.0.0`) to prevent future breaking changes

This approach:
- Resolves the compatibility issue between Flask and Werkzeug
- Ensures that security updates are automatically included
- Maintains compatibility with newer Raspberry Pi OS versions
- Prevents major version upgrades that might introduce breaking changes

## Testing
The changes have been manually tested and resolve the issue with the web service failing to start due to Flask/Werkzeug incompatibility.